### PR TITLE
Configuring Travis CI build & switching to python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 sudo: false
 
 language: python
+python:
+  - 3.4
+  - 3.5
+  - 3.6
 
 env:
-  - TOX_ENV=py27
+  - TOX_ENV=py3
   - TOX_ENV=docs
   - TOX_ENV=flake8
 
 install:
-  - "pip install tox"
+  - "pip3 install tox"
 
 script:
   - "tox -e $TOX_ENV"
 
-
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Proto Actor - Ultra fast distributed actors
 
 # Getting Started
 
-Ensure you have Python 2.7 with pip installed.
+Ensure you have Python 3.6 with pip installed.
 
 ```
-$ pip install virtualenv
+$ pip3 install virtualenv
 $ virtualenv dev.venv
 $ source dev.venv/bin/activate # on POSIX systems
 $ .\dev.venv\Scripts\activate.ps1 # on Windows
-$ pip install -r requirements.dev.txt
+$ pip3 install -r requirements.dev.txt
 ```
 
 ## Run tests

--- a/protoactor/context.py
+++ b/protoactor/context.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 
 def get_default_receive():
+    # TODO: implement this
     pass

--- a/protoactor/mailbox.py
+++ b/protoactor/mailbox.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from protoactor.utils import python_version
-
-if python_version() == 2:
-    from Queue import Queue
-else:  # Python 3
-    from queue import Queue  # pylint:disable=E0401
+from queue import Queue
 
 
 class MailboxType(object):

--- a/protoactor/pid.py
+++ b/protoactor/pid.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 class PID(object):
 
     def __init__(self, address, id, aref=None):

--- a/protoactor/process.py
+++ b/protoactor/process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from uuid import uuid4
-from messages import MessageSender, Stop
+from protoactor.messages import MessageSender, Stop
 
 
 class Process(object):
@@ -10,7 +10,7 @@ class Process(object):
     def send_user_message(self, pid, message, sender=None):
         raise NotImplementedError("You need to implement this")
 
-    def stop (self, pid):
+    def stop(self, pid):
         self.send_system_message(pid, Stop())
 
     def send_system_message(self, pid, message):
@@ -90,10 +90,11 @@ class EventStream(object):
 def _report_deadletters(msg):
     """Print a message for deadletters"""
     if isinstance(msg, DeadLetterEvent):
-        msg = """[DeadLetterEvent] %(pid)s got %(message_type)s:%(message)s from
-        %(sender)s""" % { "pid": msg.pid,
-                         "message_type": type(msg.message),
-                         "message": msg.message,
-                         "sender": msg.sender
-                         }
+        msg = """[DeadLetterEvent] %(pid)s got %(message_type)s:%(message)s
+        from %(sender)s""" % {
+            "pid": msg.pid,
+            "message_type": type(msg.message),
+            "message": msg.message,
+            "sender": msg.sender
+        }
         print(msg)

--- a/protoactor/process_registry.py
+++ b/protoactor/process_registry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import threading
-from pid import PID
-from process import DeadLettersProcess
+from protoactor.pid import PID
+from protoactor.process import DeadLettersProcess
 
 non_host = "nonhost"
 
@@ -25,14 +25,14 @@ class ProcessRegistry(object):
                 reff = resolver(pid)
                 if reff is None:
                     continue
-               		
+
                 pid.aref = reff
                 return reff
-	
+
         aref = self.__local_actor_refs.get(pid.id, None)
         if aref is not None:
             return aref
-	
+
         return DeadLettersProcess()
 
     def add(self, id, aref):

--- a/protoactor/props.py
+++ b/protoactor/props.py
@@ -1,27 +1,17 @@
-from messages import Started
-from context import get_default_receive
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from protoactor.messages import Started
+from protoactor.context import get_default_receive
 
-def get_default_spawner(name, props, parent):
-    ctx = Context(props.producer, props.supervisor_strategy, props.middleware_chain, parent)
-    mailbox = props.mailbox_producer
-    dispatcher = props.dispatcher
-    reff = LocalProcess(mailbox)
-    pr = ProcessRegistry().add(name, reff)
-    ctx.self = pid
-
-    mailbox.register_handlers(ctx, dispatcher)
-    mailbox.post_system_message(Started())
-    mailbox.start()
-
-    return pid
 
 def middleware_chain_concat(middleware):
-    rv_list = list(reverse(middleware))
+    rv_list = list(reversed(middleware))
     receieve = get_default_receive()
     for m in rv_list:
         receieve = m(receieve)
     
     return receieve
+
 
 class Props(object):
     def __init__(self, *args, **kwargs):

--- a/protoactor/restart_statistics.py
+++ b/protoactor/restart_statistics.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import datetime
+
 
 class RestartStatistics(object):
     def __init__(self, failure_count, last_failure_time):

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -4,10 +4,10 @@
 
 def test_circular_dependencies():
     """Verify that there are no circular dependencies"""
-    from protoactor.utils import *
-    from protoactor.messages import *
-    from protoactor.mailbox import *
-    from protoactor.pid import *
-    from protoactor.process import *
-    from protoactor.process_registry import *
-    from protoactor.props import *
+    from protoactor.utils import singleton, python_version
+    from protoactor.messages import AutoReceiveMessage
+    from protoactor.mailbox import MailBox
+    from protoactor.pid import PID
+    from protoactor.process import DeadLetterEvent
+    from protoactor.process_registry import ProcessRegistry
+    from protoactor.props import Props

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -13,6 +13,7 @@ def test_get_mailbox_property():
 
     assert lp.mailbox == mailbox
 
+
 def test_send_user_message():
     mailbox = MailBox()
     mailbox.post_user_message = Mock()
@@ -23,6 +24,7 @@ def test_send_user_message():
 
     assert mess == "message"
 
+
 def test_send_user_message():
     mailbox = MailBox()
     mailbox.post_system_message = Mock()
@@ -32,6 +34,7 @@ def test_send_user_message():
     mess = mailbox.post_system_message.call_args[0][0]
 
     assert mess == "message"
+
 
 def test_send_user_message_with_sender():
     mailbox = MailBox()
@@ -50,7 +53,7 @@ def test_event_stream_publish_subscribe(capsys):
     es = EventStream()
 
     def fun(x):
-        print "fun with %(val)s" % {'val': x}
+        print("fun with %(val)s" % {'val': x})
 
     es.subscribe(fun)
     es.publish("message")

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -8,7 +8,7 @@ from protoactor.process import DeadLettersProcess
 def test_get_nohost():
     test_pid = PID(address='nonhost', id='id')
     lp  = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     new_lp = pr.get(test_pid)
 
@@ -18,7 +18,7 @@ def test_get_nohost():
 def test_get_sameaddress():
     test_pid = PID(address='address', id='id')
     lp  = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     pr.address = 'address'
 
@@ -30,7 +30,7 @@ def test_get_sameaddress():
 def test_get_not_sameaddress():
     test_pid = PID(address='another_address', id='id')
     lp  = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     pr.address = 'address'
 
@@ -41,7 +41,7 @@ def test_get_not_sameaddress():
 def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
     test_pid = PID(address='address', id='id')
     lp = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
 
@@ -52,7 +52,7 @@ def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
 def test_add():
     test_pid = PID(address='address', id='id')
     lp = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
 
@@ -65,7 +65,7 @@ def test_add():
 def test_remove():
     test_pid = PID(address='address', id='id')
     lp = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
 
@@ -80,7 +80,7 @@ def test_remove():
 def test_next_id():
     test_pid = PID(address='another_address', id='id')
     lp = LocalProcess(MailBox())
-    
+
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
 

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -1,21 +1,22 @@
 import pytest
-from protoactor.props import Props, get_default_spawner
+from protoactor.props import Props
+
 
 def test_props_default_init():
     props = Props()
-    
-    assert props.producer == None
+
+    assert props.producer is None
     # TODO: change these value with concrete default instances
-    assert props.mailbox_producer == None
-    assert props.supervisor_strategy == None
-    assert props.dispatcher == None
+    assert props.mailbox_producer is None
+    assert props.supervisor_strategy is None
+    assert props.dispatcher is None
     assert props.middleware == []
-    assert props.middleware_chain == None
-   
-    assert props.spawner == get_default_spawner
+    assert props.middleware_chain is None
+
 
 class PropsObj(object):
     pass
+
 
 @pytest.mark.parametrize("field,method,value", [
     ('producer', 'with_producer', PropsObj()),
@@ -26,7 +27,7 @@ class PropsObj(object):
 def test_props_with(field, method, value):
     props = Props()
 
-    with_method =  getattr(props, method)
+    with_method = getattr(props, method)
     new_props = with_method(value)
 
     results = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, docs, flake8
+envlist = py3, docs, flake8
 
 [testenv]
 deps =
@@ -10,11 +10,7 @@ deps =
 commands =
     py.test --capture=sys --cov=protoactor tests/ -n 3
 
-[testenv:py26]
-deps =
-    {[testenv]deps}
-
-[testenv:py27]
+[testenv:py3]
 deps =
     {[testenv]deps}
 


### PR DESCRIPTION
* switch from python 2.* to python 3.6
* remove references of python 2 checks
* fix python imports for python 3
* remove get_default_spaner function since the implementation is lacking stuff
* fix middleware_chagin_concat function to call reversed
* fix a test which was failling