### PR TITLE
Fixing some circular dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: python
 python:
-  - 3.4
   - 3.5
   - 3.6
 

--- a/protoactor/actor.py
+++ b/protoactor/actor.py
@@ -1,34 +1,31 @@
 from abc import ABCMeta, abstractmethod
 from typing import Callable
 
-from .process_registry import ProcessRegistry
-from .props import Props
-from .context import AbstractContext
-from .pid import PID
+from . import process_registry, props, context, pid
 
 class Actor(metaclass=ABCMeta):
     @abstractmethod
-    async def receive(self, context: AbstractContext) -> None:
+    async def receive(self, context: context.AbstractContext) -> None:
         pass
 
 
-def from_producer(producer: Callable[[], Actor]) -> Props:
-    return Props(producer=producer)
+def from_producer(producer: Callable[[], Actor]) -> 'Props':
+    return props.Props(producer=producer)
 
 
-def from_func(receive) -> Props:
+def from_func(receive) -> 'Props':
     pass
 
 
-def spawn(props: Props) -> PID:
-    return props.spawn(ProcessRegistry().next_id())
+def spawn(props: 'Props') -> pid.PID:
+    return props.spawn(process_registry.ProcessRegistry().next_id())
 
 
-def spawn_prefix(props, prefix: str):
+def spawn_prefix(props: 'Props', prefix: str):
     pass
 
 
-def spawn_named(props, name: str):
+def spawn_named(props: 'Props', name: str):
     pass
 
 

--- a/protoactor/context.py
+++ b/protoactor/context.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 from asyncio import Task
 from datetime import timedelta
 from typing import Callable, List, Set
@@ -33,27 +33,27 @@ class AbstractContext(metaclass=ABCMeta):
         self.__actor = actor
 
     @property
-    @abstractmethod
+    @abstractproperty
     def sender(self) -> pid.PID:
         raise NotImplementedError("Should Implement this method")
 
     @property
-    @abstractmethod
+    @abstractproperty
     def message(self) -> object:
         raise NotImplementedError("Should Implement this method")
 
     @property
-    @abstractmethod
+    @abstractproperty
     def receive_timeout(self) -> timedelta:
         raise NotImplementedError("Should Implement this method")
 
     @property
-    @abstractmethod
+    @abstractproperty
     def children(self):
         raise NotImplementedError("Should Implement this method")
 
     @property
-    @abstractmethod
+    @abstractproperty
     def stash(self):
         raise NotImplementedError("Should Implement this method")
 
@@ -105,12 +105,12 @@ class LocalContext(AbstractContext, invoker.AbstractInvoker):
         self.__middleware = middleware
         self.parent = parent
 
-        self.__stopping: bool = False
-        self.__restarting: bool = False
-        self.__receive: Callable[['Actor', AbstractContext], Task] = None
-        self.__restart_statistics: restart_statistics.RestartStatistics = None
+        self.__stopping = False
+        self.__restarting = False
+        self.__receive = None
+        self.__restart_statistics = None
 
-        self.__behaviour : List[Callable[['Actor', AbstractContext], Task]]= []
+        self.__behaviour = []
         self.__incarnate_actor()
 
     def watch(self, pid: pid.PID):

--- a/protoactor/dispatcher.py
+++ b/protoactor/dispatcher.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 from asyncio import Task
 from multiprocessing import Process
 from typing import Callable
@@ -6,7 +6,7 @@ from typing import Callable
 
 class AbstractDispatcher(metaclass=ABCMeta):
     @property
-    @abstractmethod
+    @abstractproperty
     def throughput(self) -> int:
         raise NotImplementedError("Should Implement this method")
 

--- a/protoactor/dispatcher.py
+++ b/protoactor/dispatcher.py
@@ -1,9 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from asyncio import Task
-from typing import Callable
 from multiprocessing import Process
-
-from .mailbox.mailbox import AbstractMailbox
+from typing import Callable
 
 
 class AbstractDispatcher(metaclass=ABCMeta):
@@ -13,7 +11,7 @@ class AbstractDispatcher(metaclass=ABCMeta):
         raise NotImplementedError("Should Implement this method")
 
     @abstractmethod
-    def schedule(self, runner: Callable[[AbstractMailbox], Task]):
+    def schedule(self, runner: Callable[['AbstractMailbox'], Task]):
         raise NotImplementedError("Should Implement this method")
 
 
@@ -22,6 +20,6 @@ class ProcessDispatcher(AbstractDispatcher):
     def throughput(self) -> int:
         raise NotImplementedError("Should Implement this method")
 
-    def schedule(self, runner: Callable[[AbstractMailbox], Task]):
+    def schedule(self, runner: Callable[['AbstractMailbox'], Task]):
         p = Process(target=runner)
         p.start()

--- a/protoactor/invoker.py
+++ b/protoactor/invoker.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from asyncio import Task
 
 
 class AbstractInvoker(metaclass=ABCMeta):

--- a/protoactor/mailbox/mailbox.py
+++ b/protoactor/mailbox/mailbox.py
@@ -36,7 +36,7 @@ class Mailbox(AbstractMailbox):
         self.__invoker = invoker
         self.__dispatcher = dispatcher
         self.__status = MailBoxStatus.IDLE
-        self.__suspended: bool = False
+        self.__suspended = False
 
     def post_system_message(self, message: object):
         self.__system_messages_queue.push(message)

--- a/protoactor/mailbox/queue.py
+++ b/protoactor/mailbox/queue.py
@@ -20,6 +20,7 @@ class AbstractQueue(metaclass=ABCMeta):
 
 class UnboundedMailboxQueue(AbstractQueue):
     def __init__(self):
+        # TODO multiprocess.Queue empty() and full() are not reliable, Seek otherways.
         self.__messages = Queue()
 
     def pop(self) -> Optional[object]:
@@ -29,7 +30,8 @@ class UnboundedMailboxQueue(AbstractQueue):
             return None
 
     def push(self, message: object):
-        self.__messages.put_nowait(message)
+        self.__messages.put(message)
 
     def has_messages(self) -> bool:
+        # TODO multiprocess.Queue empty() and full() are not reliable, Seek otherways.
         return not self.__messages.empty()

--- a/protoactor/mailbox/queue.py
+++ b/protoactor/mailbox/queue.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from multiprocessing import Queue
-from queue import Empty
+from asyncio import Queue, QueueEmpty
 from typing import Optional
 
 
@@ -20,18 +19,16 @@ class AbstractQueue(metaclass=ABCMeta):
 
 class UnboundedMailboxQueue(AbstractQueue):
     def __init__(self):
-        # TODO multiprocess.Queue empty() and full() are not reliable, Seek otherways.
         self.__messages = Queue()
 
     def pop(self) -> Optional[object]:
         try:
             return self.__messages.get_nowait()
-        except Empty:
+        except QueueEmpty:
             return None
 
     def push(self, message: object):
-        self.__messages.put(message)
+        self.__messages.put_nowait(message)
 
     def has_messages(self) -> bool:
-        # TODO multiprocess.Queue empty() and full() are not reliable, Seek otherways.
         return not self.__messages.empty()

--- a/protoactor/message_sender.py
+++ b/protoactor/message_sender.py
@@ -1,12 +1,12 @@
-from .pid import PID
+from . import pid
 
 class MessageSender:
-    def __init__(self, message: object, sender: PID) -> None:
+    def __init__(self, message: object, sender: pid.PID) -> None:
         self.__message = message
-        self.__sender= sender
+        self.__sender = sender
 
     @property
-    def sender(self) -> PID:
+    def sender(self) -> pid.PID:
         return self.__sender
 
     @property

--- a/protoactor/messages.py
+++ b/protoactor/messages.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta
 
-from protoactor.pid import PID
-from .restart_statistics import RestartStatistics
+from. import pid, restart_statistics
 
 
 class AbstractSystemMessage(metaclass=ABCMeta):
@@ -25,13 +24,13 @@ class Restart(AbstractSystemMessage):
 
 
 class Failure(AbstractSystemMessage):
-    def __init__(self, who: PID, reason: Exception, crs: RestartStatistics) -> None:
+    def __init__(self, who: pid.PID, reason: Exception, crs: restart_statistics.RestartStatistics) -> None:
         self.__who = who
         self.__reason = reason
         self.__crs = crs
 
     @property
-    def who(self) -> PID:
+    def who(self) -> pid.PID:
         return self.__who
 
     @property
@@ -39,17 +38,17 @@ class Failure(AbstractSystemMessage):
         return self.__reason
 
     @property
-    def restart_statistics(self) -> RestartStatistics:
+    def restart_statistics(self) -> restart_statistics.RestartStatistics:
         return self.__crs
 
 
 class Watch(AbstractSystemMessage):
-    def __init__(self, watcher: PID) -> None:
+    def __init__(self, watcher: pid.PID) -> None:
         self.watcher = watcher
 
 
 class Unwatch(AbstractSystemMessage):
-    def __init__(self, watcher: PID) -> None:
+    def __init__(self, watcher: pid.PID) -> None:
         self.watcher = watcher
 
 

--- a/protoactor/pid.py
+++ b/protoactor/pid.py
@@ -2,14 +2,14 @@ class PID:
     def __init__(self, address: str, id: str, ref: 'AbstractProcess') -> None:
         self.__address = address
         self.__id = id
-        self.__process: 'AbstractProcess' = ref
+        self.__process = ref
 
     @property
-    def address(self):
+    def address(self) -> str:
         return self.__address
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self.__id
 
     @property
@@ -23,11 +23,11 @@ class PID:
     def __repr__(self):
         return "{} / {}".format(self.__address, self.__id)
 
-    def tell(self, msg):
-        self.__process.send_user_message(self, msg)
+    def tell(self, message):
+        self.__process.send_user_message(self, message)
 
-    def send_system_message(self, sys):
-        pass
+    def send_system_message(self, message):
+        self.__process.send_system_message(self, message)
 
     def stop(self):
         self.__process.stop()

--- a/protoactor/pid.py
+++ b/protoactor/pid.py
@@ -1,12 +1,8 @@
-from .process import AbstractProcess
-from .process_registry import ProcessRegistry
-
-
 class PID:
-    def __init__(self, address: str, id: str, ref: AbstractProcess) -> None:
+    def __init__(self, address: str, id: str, ref: 'AbstractProcess') -> None:
         self.__address = address
         self.__id = id
-        self.__process: AbstractProcess = ref
+        self.__process: 'AbstractProcess' = ref
 
     @property
     def address(self):
@@ -17,20 +13,17 @@ class PID:
         return self.__id
 
     @property
-    def process(self) -> AbstractProcess:
+    def process(self) -> 'AbstractProcess':
         return self.__process
 
     @process.setter
-    def process(self, ref: AbstractProcess) -> None:
+    def process(self, ref: 'AbstractProcess') -> None:
         self.__process = ref
 
     def __repr__(self):
         return "{} / {}".format(self.__address, self.__id)
 
     def tell(self, msg):
-        if not self.__process:
-            self.__process = ProcessRegistry().get(self)
-
         self.__process.send_user_message(self, msg)
 
     def send_system_message(self, sys):

--- a/protoactor/process.py
+++ b/protoactor/process.py
@@ -80,7 +80,7 @@ class DeadLetterEvent:
 @utils.singleton
 class EventStream:
     def __init__(self):
-        self._subscriptions: Dict[uuid4, Callable[..., None]] = {}
+        self._subscriptions = {}
         self.subscribe(self.__report_deadletters)
 
     def subscribe(self, fun: Callable[..., None]) -> None:

--- a/protoactor/process.py
+++ b/protoactor/process.py
@@ -3,20 +3,17 @@ from asyncio import Task
 from typing import Dict, Optional, Callable
 from uuid import uuid4
 
-from protoactor.utils import singleton
-from .invoker import AbstractInvoker
-from .mailbox.mailbox import AbstractMailbox
-from .message_sender import MessageSender
-from .pid import PID
+from . import utils, invoker, message_sender, pid
+from .mailbox import mailbox
 
 
 class AbstractProcess(metaclass=ABCMeta):
     @abstractmethod
-    def send_user_message(self, pid: PID, message: object, sender: PID = None):
+    def send_user_message(self, pid: 'PID', message: object, sender: 'PID' = None):
         raise NotImplementedError('Should implement this method')
 
     @abstractmethod
-    def send_system_message(self, pid: PID, message: object):
+    def send_system_message(self, pid: 'PID', message: object):
         raise NotImplementedError('Should implement this method')
 
     @abstractmethod
@@ -24,17 +21,17 @@ class AbstractProcess(metaclass=ABCMeta):
         raise NotImplementedError('Should implement this method')
 
 
-class LocalProcess(AbstractProcess, AbstractInvoker):
-    def __init__(self, mailbox: AbstractMailbox) -> None:
+class LocalProcess(AbstractProcess, invoker.AbstractInvoker):
+    def __init__(self, mailbox: mailbox.AbstractMailbox) -> None:
         self.__mailbox = mailbox
 
-    def send_user_message(self, pid: PID, message: object, sender: PID = None):
+    def send_user_message(self, pid: 'PID', message: object, sender: 'PID' = None):
         if sender:
-            self.__mailbox.post_user_message(MessageSender(message, sender))
+            self.__mailbox.post_user_message(message_sender.MessageSender(message, sender))
         else:
             self.__mailbox.post_user_message(message)
 
-    def send_system_message(self, pid: PID, message: object):
+    def send_system_message(self, pid: 'PID', message: object):
         self.__mailbox.post_system_message(message)
 
     def stop(self):
@@ -54,21 +51,21 @@ class DeadLettersProcess(AbstractProcess):
     def stop(self):
         raise NotImplementedError("Should Implement this method")
 
-    def send_system_message(self, pid: PID, message: object):
+    def send_system_message(self, pid: 'PID', message: object):
         EventStream().publish(DeadLetterEvent(pid, message, None))
 
-    def send_user_message(self, pid: PID, message: object, sender: PID = None):
+    def send_user_message(self, pid: 'PID', message: object, sender: 'PID' = None):
         EventStream().publish(DeadLetterEvent(pid, message, sender))
 
 
 class DeadLetterEvent:
-    def __init__(self, pid: PID, message: object, sender: Optional[PID]) -> None:
+    def __init__(self, pid: 'PID', message: object, sender: Optional['PID']) -> None:
         self.__pid = pid
         self.__message = message
         self.__sender = sender
 
     @property
-    def pid(self) -> PID:
+    def pid(self) -> 'PID':
         return self.__pid
 
     @property
@@ -76,11 +73,11 @@ class DeadLetterEvent:
         return self.__message
 
     @property
-    def sender(self) -> PID:
+    def sender(self) -> Optional['PID']:
         return self.__sender
 
 
-@singleton
+@utils.singleton
 class EventStream:
     def __init__(self):
         self._subscriptions: Dict[uuid4, Callable[..., None]] = {}

--- a/protoactor/process_registry.py
+++ b/protoactor/process_registry.py
@@ -7,9 +7,9 @@ from . import utils, pid as pid_, process
 @utils.singleton
 class ProcessRegistry:
     def __init__(self, resolver=None, host: str = "nonhost") -> None:
-        self._hostResolvers = [resolver]
+        self._hostResolvers = [resolver] if resolver is not None else []
         # python dict structure is atomic for primitive actions. Need to be checked
-        self.__local_actor_refs: Dict = {}
+        self.__local_actor_refs = {}
         self.__sequence_id = 0
         self.__address = host
         self.__lock = RLock()

--- a/protoactor/process_registry.py
+++ b/protoactor/process_registry.py
@@ -1,14 +1,12 @@
 from multiprocessing import RLock
 from typing import Dict
 
-from .pid import PID
-from .process import AbstractProcess, DeadLettersProcess
-from .utils import singleton
+from . import utils, pid as pid_, process
 
 
-@singleton
+@utils.singleton
 class ProcessRegistry:
-    def __init__(self, resolver = None, host :str = "nonhost") -> None:
+    def __init__(self, resolver=None, host: str = "nonhost") -> None:
         self._hostResolvers = [resolver]
         # python dict structure is atomic for primitive actions. Need to be checked
         self.__local_actor_refs: Dict = {}
@@ -21,31 +19,31 @@ class ProcessRegistry:
         return self.__address
 
     @address.setter
-    def address(self, address:str):
+    def address(self, address: str):
         self.__address = address
 
-    def get(self, pid:PID) -> AbstractProcess:
+    def get(self, pid: 'PID') -> process.AbstractProcess:
         if pid.address != self.__address:
             for resolver in self._hostResolvers:
                 reff = resolver(pid)
-                if not reff:
+                if reff is None:
                     continue
 
                 pid.process = reff
                 return reff
 
         ref = self.__local_actor_refs.get(pid.id, None)
-        if ref:
+        if ref is not None:
             return ref
 
-        return DeadLettersProcess()
+        return process.DeadLettersProcess()
 
-    def add(self, id:str, ref:AbstractProcess) -> PID:
-        pid = PID(address=self.address, id=id, ref=ref)
+    def add(self, id: str, ref: process.AbstractProcess) -> 'PID':
+        _pid = pid_.PID(address=self.address, id=id, ref=ref)
         self.__local_actor_refs[id] = ref
-        return pid
+        return _pid
 
-    def remove(self, pid):
+    def remove(self, pid: 'PID'):
         self.__local_actor_refs.pop(pid.id)
 
     def next_id(self) -> str:

--- a/protoactor/props.py
+++ b/protoactor/props.py
@@ -46,6 +46,10 @@ class Props:
         return self.__producer
 
     @property
+    def mailbox_producer(self) -> Callable[[invoker.AbstractInvoker, 'AbstractDispatcher'], mailbox.AbstractMailbox]:
+        return self.__mailbox_producer
+
+    @property
     def supervisor(self):
         return self.__supervisor_strategy
 
@@ -83,4 +87,9 @@ class Props:
         params = self.__dict__
         params.update(new_params)
 
-        return Props(**params)
+        _params = {}
+        for key in params:
+            new_key = key.replace('_Props__', '')
+            _params[new_key] = params[key]
+
+        return Props(**_params)

--- a/protoactor/props.py
+++ b/protoactor/props.py
@@ -1,46 +1,38 @@
 from asyncio import Task
 from typing import Callable, List
 
-from .actor import Actor
-from .context import LocalContext, AbstractContext
-from .dispatcher import AbstractDispatcher, ProcessDispatcher
-from .invoker import AbstractInvoker
-from .mailbox.mailbox import AbstractMailbox, Mailbox
-from .mailbox.queue import UnboundedMailboxQueue
-from .messages import Started
-from .pid import PID
-from .process import LocalProcess
-from .process_registry import ProcessRegistry
-from .supervision import AbstractSupervisorStrategy
+from . import actor, context, dispatcher, invoker, messages, pid, process, process_registry, supervision
+from .mailbox import mailbox, queue
 
 
-def default_spawner(id: str, props: 'Props', parent: PID) -> PID:
-    context = LocalContext(props.producer, props.supervisor, props.middleware_chain, parent)
-    mailbox = props.produce_mailbox(context, props.dispatcher)
-    process = LocalProcess(mailbox)
+def default_spawner(id: str, props: 'Props', parent: pid.PID) -> pid.PID:
+    _context = context.LocalContext(props.producer, props.supervisor, props.middleware_chain, parent)
+    mailbox = props.produce_mailbox(_context, props.dispatcher)
+    _process = process.LocalProcess(mailbox)
 
-    pid = ProcessRegistry().add(id, process)
-    context.my_self = pid
+    pid = process_registry.ProcessRegistry().add(id, _process)
+    _context.my_self = pid
 
     mailbox.start()
-    mailbox.post_system_message(Started())
+    mailbox.post_system_message(messages.Started())
 
     return pid
 
 
-def default_mailbox_producer(invoker: AbstractInvoker, dispatcher: AbstractDispatcher):
-    return Mailbox(UnboundedMailboxQueue(), UnboundedMailboxQueue(), invoker, dispatcher)
+def default_mailbox_producer(invoker: invoker.AbstractInvoker, dispatcher: 'AbstractDispatcher'):
+    return mailbox.Mailbox(queue.UnboundedMailboxQueue(), queue.UnboundedMailboxQueue(), invoker, dispatcher)
 
 
 class Props:
-    def __init__(self, producer: Callable[[], Actor] = None,
-                 spawner: Callable[[str, 'Props', PID], PID] = default_spawner,
+    def __init__(self, producer: Callable[[], actor.Actor] = None,
+                 spawner: Callable[[str, 'Props', pid.PID], pid.PID] = default_spawner,
                  mailbox_producer: Callable[
-                     [AbstractInvoker, AbstractDispatcher], AbstractMailbox] = default_mailbox_producer,
-                 dispatcher: AbstractDispatcher = ProcessDispatcher(),
-                 supervisor_strategy: AbstractSupervisorStrategy = None,
-                 middleware: List[Callable[[AbstractContext], Task]] = None,
-                 middleware_chain: Callable[[AbstractContext], Task] = None) -> None:
+                     [invoker.AbstractInvoker,
+                      'AbstractDispatcher'], mailbox.AbstractMailbox] = default_mailbox_producer,
+                 dispatcher: 'AbstractDispatcher' = dispatcher.ProcessDispatcher(),
+                 supervisor_strategy: supervision.AbstractSupervisorStrategy = None,
+                 middleware: List[Callable[[context.AbstractContext], Task]] = None,
+                 middleware_chain: Callable[[context.AbstractContext], Task] = None) -> None:
         self.__producer = producer
         self.__spawner = spawner
         self.__mailbox_producer = mailbox_producer
@@ -50,7 +42,7 @@ class Props:
         self.__middleware_chain = middleware_chain
 
     @property
-    def producer(self) -> Callable[[], Actor]:
+    def producer(self) -> Callable[[], actor.Actor]:
         return self.__producer
 
     @property
@@ -65,25 +57,26 @@ class Props:
     def dispatcher(self):
         return self.__dispatcher
 
-    def with_producer(self, producer: Callable[[], Actor]) -> 'Props':
+    def with_producer(self, producer: Callable[[], actor.Actor]) -> 'Props':
         return self.__copy_with({'_Props__producer': producer})
 
-    def with_dispatcher(self, dispatcher: AbstractDispatcher) -> 'Props':
+    def with_dispatcher(self, dispatcher: 'AbstractDispatcher') -> 'Props':
         return self.__copy_with({'_Props__dispatcher': dispatcher})
 
-    def with_middleware(self, middleware: List[Callable[[AbstractContext], Task]]) -> 'Props':
+    def with_middleware(self, middleware: List[Callable[[context.AbstractContext], Task]]) -> 'Props':
         return self.__copy_with({'_Props__middleware': middleware})
 
-    def with_mailbox_producer(self, mailbox_producer: Callable[[], AbstractMailbox]) -> 'Props':
+    def with_mailbox_producer(self, mailbox_producer: Callable[[], mailbox.AbstractMailbox]) -> 'Props':
         return self.__copy_with({'_Props__mailbox_producer': mailbox_producer})
 
     def with_supervisor_strategy(self, supervisor_strategy) -> 'Props':
         return self.__copy_with({'_Props__supervisor_strategy': supervisor_strategy})
 
-    def spawn(self, id: str, parent: PID = None) -> PID:
+    def spawn(self, id: str, parent: pid.PID = None) -> pid.PID:
         return self.__spawner(id, self, parent)
 
-    def produce_mailbox(self, invoker: AbstractInvoker, dispatcher: AbstractDispatcher) -> AbstractMailbox:
+    def produce_mailbox(self, invoker: invoker.AbstractInvoker,
+                        dispatcher: 'AbstractDispatcher') -> mailbox.AbstractMailbox:
         return self.__mailbox_producer(invoker, dispatcher)
 
     def __copy_with(self, new_params: dict) -> 'Props':

--- a/protoactor/restart_statistics.py
+++ b/protoactor/restart_statistics.py
@@ -21,7 +21,7 @@ class RestartStatistics:
 
         self.__failure_count += 1
 
-        if not within_timedelta:
+        if within_timedelta is None:
             return self.__failure_count <= max_retries_number
 
         max = datetime.datetime.now() - within_timedelta

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,6 @@
 sphinx
 flake8
 pytest
-mock
 tox
 pytest-cov
 pytest-xdist

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -6,7 +6,7 @@ def test_circular_dependencies():
     """Verify that there are no circular dependencies"""
     from protoactor.utils import singleton, python_version
     from protoactor.messages import AutoReceiveMessage
-    from protoactor.mailbox import MailBox
+    from protoactor.mailbox.mailbox import Mailbox
     from protoactor.pid import PID
     from protoactor.process import DeadLetterEvent
     from protoactor.process_registry import ProcessRegistry

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -2,39 +2,9 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from protoactor.mailbox import UnboundedMailboxQueue, _MailboxQueue
+from protoactor.mailbox import mailbox
 
 
-def test_mailbox_adds():
-    mailbox = UnboundedMailboxQueue()
-    mailbox.push("1")
-
-
-def test_mailbox_has_messages_returns_false_when_empty():
-    mailbox = UnboundedMailboxQueue()
-    assert mailbox.has_messages() == False
-
-
-def test_mailbox_adds_successfully():
-    mailbox = UnboundedMailboxQueue()
-    mailbox.push("1")
-    assert mailbox.has_messages() == True
-
-
-def test_mailbox_removes_successfully():
-    mailbox = UnboundedMailboxQueue()
-    mailbox.push("1")
-    msg = mailbox.pop()
-    assert msg == "1"
-
-
-def test_mailbox_queue_throws_not_implemented():
-    mailbox = _MailboxQueue()
-    with pytest.raises(NotImplementedError):
-        mailbox.push("1")
-
-
-def test_mailbox_queue_removes_throws_not_implemented():
-    mailbox = _MailboxQueue()
-    with pytest.raises(NotImplementedError):
-        mailbox.pop()
+def test_create_abstract_mailbox():
+    with pytest.raises(TypeError):
+        _mailbox = mailbox.AbstractMailbox()

--- a/tests/test_mailbox_queue.py
+++ b/tests/test_mailbox_queue.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+
+from protoactor.mailbox import queue
+
+
+@pytest.fixture
+def unbounded_queue():
+    return queue.UnboundedMailboxQueue()
+
+
+def test_unbounded_mailbox_queue_push_pop(unbounded_queue):
+    unbounded_queue.push("1")
+    assert unbounded_queue.pop() == "1"
+
+
+def test_unbounded_mailbox_queue_pop_empty(unbounded_queue):
+    assert unbounded_queue.pop() is None
+
+
+def test_unbounded_mailbox_queue_has_message(unbounded_queue):
+    unbounded_queue.push("1")
+    assert unbounded_queue.has_messages() == True
+
+
+def test_unbounded_mailbox_queue_has_message_empty(unbounded_queue):
+    assert unbounded_queue.has_messages() == False
+
+
+def test_create_abstract_queue():
+    with pytest.raises(TypeError):
+        _queue = queue.AbstractQueue()

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest import mock
+from protoactor import pid
+
+
+@pytest.fixture
+def mocked_pid():
+    _process = mock.Mock()
+    _process.send_user_message = mock.MagicMock(return_value=None)
+    _process.send_system_message = mock.MagicMock(return_value=None)
+    _process.stop = mock.MagicMock(return_value=None)
+    return pid.PID("sample_address", "sample_id", _process)
+
+
+def test_adress(mocked_pid):
+    assert mocked_pid.address == "sample_address"
+
+
+def test_id(mocked_pid):
+    assert mocked_pid.id == "sample_id"
+
+
+def test_tell(mocked_pid):
+    message = "test_message"
+    mocked_pid.tell(message)
+    mocked_pid.process.send_user_message.assert_called_once_with(mocked_pid, message)
+
+
+def test_send_system_message(mocked_pid):
+    message = "test_message"
+    mocked_pid.send_system_message(message)
+    mocked_pid.process.send_system_message.assert_called_once_with(mocked_pid, message)
+
+
+def test_stop(mocked_pid):
+    mocked_pid.stop()
+    mocked_pid.process.stop.assert_called_once()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from protoactor.process import LocalProcess, EventStream, DeadLetterEvent
-from protoactor.mailbox import MailBox
-from protoactor.messages import MessageSender
+from protoactor.mailbox.mailbox import Mailbox
+from protoactor.message_sender import MessageSender
 
 
 def test_get_mailbox_property():
-    mailbox = MailBox()
+    mailbox = Mailbox()
     lp = LocalProcess(mailbox)
 
     assert lp.mailbox == mailbox
 
 
 def test_send_user_message():
-    mailbox = MailBox()
+    mailbox = Mailbox()
     mailbox.post_user_message = Mock()
 
     lp = LocalProcess(mailbox)
@@ -26,7 +26,7 @@ def test_send_user_message():
 
 
 def test_send_user_message():
-    mailbox = MailBox()
+    mailbox = Mailbox()
     mailbox.post_system_message = Mock()
 
     lp = LocalProcess(mailbox)
@@ -37,7 +37,7 @@ def test_send_user_message():
 
 
 def test_send_user_message_with_sender():
-    mailbox = MailBox()
+    mailbox = Mailbox()
     mailbox.post_user_message = Mock()
 
     lp = LocalProcess(mailbox)

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -2,12 +2,12 @@ import pytest
 from protoactor.process_registry import ProcessRegistry
 from protoactor.pid import PID
 from protoactor.process import LocalProcess
-from protoactor.mailbox import MailBox
+from protoactor.mailbox.mailbox import Mailbox
 from protoactor.process import DeadLettersProcess
 
 def test_get_nohost():
     test_pid = PID(address='nonhost', id='id')
-    lp  = LocalProcess(MailBox())
+    lp  = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     new_lp = pr.get(test_pid)
@@ -17,7 +17,7 @@ def test_get_nohost():
 
 def test_get_sameaddress():
     test_pid = PID(address='address', id='id')
-    lp  = LocalProcess(MailBox())
+    lp  = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     pr.address = 'address'
@@ -29,7 +29,7 @@ def test_get_sameaddress():
 
 def test_get_not_sameaddress():
     test_pid = PID(address='another_address', id='id')
-    lp  = LocalProcess(MailBox())
+    lp  = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
     pr.address = 'address'
@@ -40,7 +40,7 @@ def test_get_not_sameaddress():
 
 def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
     test_pid = PID(address='address', id='id')
-    lp = LocalProcess(MailBox())
+    lp = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
@@ -51,7 +51,7 @@ def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
 
 def test_add():
     test_pid = PID(address='address', id='id')
-    lp = LocalProcess(MailBox())
+    lp = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
@@ -64,7 +64,7 @@ def test_add():
 
 def test_remove():
     test_pid = PID(address='address', id='id')
-    lp = LocalProcess(MailBox())
+    lp = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'
@@ -79,7 +79,7 @@ def test_remove():
 
 def test_next_id():
     test_pid = PID(address='another_address', id='id')
-    lp = LocalProcess(MailBox())
+    lp = LocalProcess(Mailbox())
 
     pr = ProcessRegistry(lambda x: None)
     pr.address = 'address'

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -1,87 +1,90 @@
 import pytest
+from unittest import mock
 from protoactor.process_registry import ProcessRegistry
 from protoactor.pid import PID
 from protoactor.process import LocalProcess
 from protoactor.mailbox.mailbox import Mailbox
 from protoactor.process import DeadLettersProcess
 
-def test_get_nohost():
-    test_pid = PID(address='nonhost', id='id')
-    lp  = LocalProcess(Mailbox())
 
-    pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
-    new_lp = pr.get(test_pid)
-
-    assert isinstance(new_lp, DeadLettersProcess) is True
+@pytest.fixture
+def nohost():
+    return ProcessRegistry()
 
 
-def test_get_sameaddress():
-    test_pid = PID(address='address', id='id')
-    lp  = LocalProcess(Mailbox())
-
-    pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
-    pr.address = 'address'
-
-    new_lp = pr.get(test_pid)
-
-    assert isinstance(new_lp, DeadLettersProcess) is True
+@pytest.fixture
+def mock_process():
+    return mock.Mock()
 
 
-def test_get_not_sameaddress():
-    test_pid = PID(address='another_address', id='id')
-    lp  = LocalProcess(Mailbox())
-
-    pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
-    pr.address = 'address'
-
-    new_lp = pr.get(test_pid)
-
-    assert test_pid.aref == lp
-
-def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
-    test_pid = PID(address='address', id='id')
-    lp = LocalProcess(Mailbox())
-
-    pr = ProcessRegistry(lambda x: None)
-    pr.address = 'address'
-
-    new_lp = pr.get(test_pid)
-
-    assert isinstance(new_lp, DeadLettersProcess) is True
-
-def test_add():
-    test_pid = PID(address='address', id='id')
-    lp = LocalProcess(Mailbox())
-
-    pr = ProcessRegistry(lambda x: None)
-    pr.address = 'address'
-
-    pr.add('id', lp)
-    new_lp = pr.get(test_pid)
-
-    assert isinstance(new_lp, DeadLettersProcess) is False
+def test_nonhost_address(nohost: ProcessRegistry):
+    assert nohost.address == 'nonhost'
 
 
-def test_remove():
-    test_pid = PID(address='address', id='id')
-    lp = LocalProcess(Mailbox())
+def test_set_address(nohost: ProcessRegistry):
+    nohost.address = 'new_host'
+    assert nohost.address == 'new_host'
 
-    pr = ProcessRegistry(lambda x: None)
-    pr.address = 'address'
 
-    pr.add('id', lp)
-    added_lp = pr.get(test_pid)
-    assert isinstance(added_lp, DeadLettersProcess) is False
+def test_next_id(nohost: ProcessRegistry):
+    assert nohost.next_id() == '1'
 
-    pr.remove(test_pid)
-    removed_lp = pr.get(test_pid)
-    assert isinstance(removed_lp, DeadLettersProcess) is True
 
-def test_next_id():
-    test_pid = PID(address='another_address', id='id')
-    lp = LocalProcess(Mailbox())
+def test_add(nohost: ProcessRegistry, mock_process):
+    _pid = ProcessRegistry().add('new_id', mock_process)
+    assert _pid.address == ProcessRegistry().address
+    assert _pid.id == 'new_id'
+    assert _pid.process == mock_process
 
-    pr = ProcessRegistry(lambda x: None)
-    pr.address = 'address'
 
-    assert pr.next_id() == 1
+def test_remove(nohost: ProcessRegistry, mock_process):
+    _pid = ProcessRegistry().add('new_id', mock_process)
+    assert ProcessRegistry().get(_pid) == mock_process
+    ProcessRegistry().remove(_pid)
+    assert isinstance(ProcessRegistry().get(_pid), DeadLettersProcess) is True
+
+
+def test_get_deadletter():
+    _pid = mock.Mock()
+    _pid.address = 'other_host'
+    _pid.pid = '9999'
+    assert isinstance(ProcessRegistry().get(_pid), DeadLettersProcess) is True
+
+
+def test_get_nonhost(nohost: ProcessRegistry, mock_process):
+    _pid = ProcessRegistry().add('new_id', mock_process)
+    assert ProcessRegistry().get(_pid) == mock_process
+
+# def test_get_sameaddress():
+#     test_pid = PID(address='address', id='id')
+#     lp  = LocalProcess(Mailbox())
+#
+#     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
+#     pr.address = 'address'
+#
+#     new_lp = pr.get(test_pid)
+#
+#     assert isinstance(new_lp, DeadLettersProcess) is True
+#
+#
+# def test_get_not_sameaddress():
+#     test_pid = PID(address='another_address', id='id')
+#     lp  = LocalProcess(Mailbox())
+#
+#     pr = ProcessRegistry(lambda x: lp if x == test_pid else None)
+#     pr.address = 'address'
+#
+#     new_lp = pr.get(test_pid)
+#
+#     assert test_pid.aref == lp
+#
+# def test_get__local_actor_refs_not_has_id_DeadLettersProcess():
+#     test_pid = PID(address='address', id='id')
+#     lp = LocalProcess(Mailbox())
+#
+#     pr = ProcessRegistry(lambda x: None)
+#     pr.address = 'address'
+#
+#     new_lp = pr.get(test_pid)
+#
+#     assert isinstance(new_lp, DeadLettersProcess) is True

--- a/tests/test_restart_statistics.py
+++ b/tests/test_restart_statistics.py
@@ -1,6 +1,6 @@
 import pytest
 import datetime
-import mock
+from unittest import mock
 from datetime import timedelta
 from protoactor.restart_statistics import RestartStatistics
 

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -18,7 +18,7 @@ def supervisor_data():
     supervisor = Supervisor()
     mailbox = Mailbox()
     local_process = LocalProcess(mailbox)
-    pid_child = PID(address='address', id='id', aref=local_process)
+    pid_child = PID(address='address', id='id', ref=local_process)
     restart_statistic = RestartStatistics(5, datetime(2017, 2, 15))
 
     return {

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -3,19 +3,20 @@
 import pytest
 import unittest
 from datetime import timedelta, datetime
-from mock import Mock
+from unittest.mock import Mock
 from protoactor.supervision import OneOfOneStrategy, SupervisorDirective, Supervisor
 from protoactor.pid import PID
 from protoactor.process_registry import ProcessRegistry
 from protoactor.restart_statistics import RestartStatistics
 from protoactor.process import LocalProcess
-from protoactor.mailbox import MailBox
-from protoactor.messages import ResumeMailbox, Restart, Stop
+from protoactor.mailbox.mailbox import Mailbox
+from protoactor.mailbox.messages import ResumeMailbox
+from protoactor.messages import Restart, Stop
 
 @pytest.fixture(scope='module', )
 def supervisor_data():
     supervisor = Supervisor()
-    mailbox = MailBox()
+    mailbox = Mailbox()
     local_process = LocalProcess(mailbox)
     pid_child = PID(address='address', id='id', aref=local_process)
     restart_statistic = RestartStatistics(5, datetime(2017, 2, 15))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 from protoactor.utils import singleton
 
 
-def test_python_version_does_not_break():
+def test_singleton():
 
     @singleton
     class TestSingleton(object):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py3, docs, flake8
 
 [testenv]
 deps =
-    mock
     pytest
     pytest-cov
     pytest-xdist


### PR DESCRIPTION
Remove Python 3.4 from travis
Remove mock dev dependency since in Python 3 it is part of the standard lib
Fixing some tests